### PR TITLE
AZ400-330. Configure Prometheus AlertManager for routing alerts to a separate Slack channel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = lf
+max_line_length = off
 
 [*.{xml,yml,yaml,json,tf,md}]
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,6 @@ and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec
 - Configure rules: CPU, RAM, Disk, Shutdown
 - Minor fixes in scripts
 - Configure rules: CPU, RAM, Disk, Shutdown (Windows)
+- Stress test for linux: `stress-ng`
+- Stress test for windows: `heavyload`
+- Update readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec
 - Configure Alert Manager
 - Configure rules: CPU, RAM, Disk, Shutdown
 - Minor fixes in scripts
+- Configure rules: CPU, RAM, Disk, Shutdown (Windows)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ PowerShell and Bash.
 Configure the Prometheus server using Bash and Terraform `remote-exec` provisioners.
 
 - https://dev.azure.com/PetroKolosovProjects/PrometheusLearning
+- https://api.slack.com/apps
 
 ## Configure Alert Manager
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,21 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 - https://dev.azure.com/PetroKolosovProjects/PrometheusLearning
 - https://api.slack.com/apps
 
+## URLs
+
+- [Prometheus Server HTTP Nginx](http://prometheus-master.razumovsky.me)
+- [Prometheus Server Web UI](http://prometheus-master.razumovsky.me:9090)
+- [AlertManager Web UI](http://prometheus-master.razumovsky.me:9093)
+- [Grafana Web UI](http://prometheus-master.razumovsky.me:3000/login)
+- [Linux Node HTTP Nginx](http://linux-target.razumovsky.me)
+- [Prometheus Linux Node Exporter Metrics](http://linux-target.razumovsky.me:9100/metrics)
+- [Windows Node HTTP IIS](http://windows-target.razumovsky.me)
+- [Prometheus Windows Node Exporter Metrics](http://windows-target.razumovsky.me:9182/metrics)
+
 ## Configure Alert Manager
 
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager.sh | sudo bash`
-- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Config.sh | sudo bash`
+- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/AZ400-330/scripts/Install-AlertManager-Config.sh | sudo bash`
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Service.sh | sudo bash`
 
 ## Stress Tests Windows
@@ -39,17 +50,6 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
     Invoke-WebRequest -Uri $scriptUrl -OutFile $localScriptPath;
     PowerShell -ExecutionPolicy Bypass -File $localScriptPath
 ```
-
-## URLs
-
-- [Prometheus Server HTTP Nginx](http://prometheus-master.razumovsky.me)
-- [Prometheus Server Web UI](http://prometheus-master.razumovsky.me:9090)
-- [AlertManager Web UI](http://prometheus-master.razumovsky.me:9093)
-- [Grafana Web UI](http://prometheus-master.razumovsky.me:3000/login)
-- [Linux Node HTTP Nginx](http://linux-target.razumovsky.me)
-- [Prometheus Linux Node Exporter Metrics](http://linux-target.razumovsky.me:9100/metrics)
-- [Windows Node HTTP IIS](http://windows-target.razumovsky.me)
-- [Prometheus Windows Node Exporter Metrics](http://windows-target.razumovsky.me:9182/metrics)
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 ## Configure Alert Manager
 
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager.sh | sudo bash`
-- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/AZ400-330/scripts/Install-AlertManager-Config.sh | sudo bash`
+- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Config.sh | sudo bash`
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Service.sh | sudo bash`
 
 ## Stress Tests Windows

--- a/README.md
+++ b/README.md
@@ -13,14 +13,21 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Config.sh | sudo bash`
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Service.sh | sudo bash`
 
-## Exporters
+## Configure Prometheus and Grafana
 
-- Master node: https://github.com/prometheus/prometheus
-- Alert manager: https://github.com/prometheus/alertmanager
-- Linux node exporter: https://github.com/prometheus/node_exporter
-- Windows node exporter: https://github.com/prometheus-community/windows_exporter
+- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Linux-Prometheus-Server.sh | sudo bash`
+- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Grafana.sh | sudo bash`
+- `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Linux-Node-Exporter.sh | sudo bash`
+-
 
-## DNS
+```powershell
+    $scriptUrl = "https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Windows-Exporter.ps1";
+    $localScriptPath = "$env:TEMP\Install-Windows-Exporter.ps1";
+    Invoke-WebRequest -Uri $scriptUrl -OutFile $localScriptPath;
+    PowerShell -ExecutionPolicy Bypass -File $localScriptPath
+```
+
+## URLs
 
 - [Prometheus Server HTTP Nginx](http://prometheus-master.razumovsky.me)
 - [Prometheus Server Web UI](http://prometheus-master.razumovsky.me:9090)
@@ -31,24 +38,6 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 - [Windows Node HTTP IIS](http://windows-target.razumovsky.me)
 - [Prometheus Windows Node Exporter Metrics](http://windows-target.razumovsky.me:9182/metrics)
 
-## SSH connection
-
-- ssh razumovsky_r@prometheus-master.razumovsky.me
-- ssh razumovsky_r@linux-target.razumovsky.me
-- ssh -o StrictHostKeyChecking=no razumovsky_r@prometheus-master.razumovsky.me
-- ssh -o StrictHostKeyChecking=no razumovsky_r@linux-target.razumovsky.me
-
-## Configure Prometheus and Grafana
-
-- Prometheus Server:
-  `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Linux-Prometheus-Server.sh | sudo bash`
-- Grafana:
-   `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/AZ400-327/scripts/Install-Grafana.sh | sudo bash`
-- Prometheus Linux Node exporter:
-  `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/master/scripts/Install-Linux-Node-Exporter.sh | sudo bash`
-- Prometheus Windows Node exporter:
-  `$scriptUrl = "https://raw.githubusercontent.com/kolosovpetro/Prometheus/master/scripts/Install-Windows-Exporter.ps1";$localScriptPath = "$env:TEMP\Install-Windows-Exporter.ps1";Invoke-WebRequest -Uri $scriptUrl -OutFile $localScriptPath;PowerShell -ExecutionPolicy Bypass -File $localScriptPath`
-
 ## Notes
 
 - Linux default scrape port: 9100
@@ -56,12 +45,19 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 - WinRM HTTP port: 5985
 - WinRM HTTPS port: 5986
 
+## Exporters
+
+- Master node: https://github.com/prometheus/prometheus
+- Alert manager: https://github.com/prometheus/alertmanager
+- Linux node exporter: https://github.com/prometheus/node_exporter
+- Windows node exporter: https://github.com/prometheus-community/windows_exporter
+
 ## Docs
 
 - Daemon using outdated libraries fix: https://stackoverflow.com/q/73397110
-    - `/etc/needrestart/needrestart.conf`
-    - `$nrconf{restart} = 'a';`
-    -
+  - `/etc/needrestart/needrestart.conf`
+  - `$nrconf{restart} = 'a';`
+  -
   `sudo curl -o /etc/needrestart/needrestart.conf https://raw.githubusercontent.com/kolosovpetro/prometheus-learning/refs/heads/master/needrestart.conf`
 
 ## Terraform provisioners

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Configure the Prometheus server using Bash and Terraform `remote-exec` provision
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Config.sh | sudo bash`
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-AlertManager-Service.sh | sudo bash`
 
+## Stress Tests Windows
+
+- `choco install heavyload -y`
+
+## Stress Tests Linux
+
+- `sudo apt-get -y install stress-ng`
+- `stress-ng --vm-bytes $(awk '/MemFree/{printf "%d\n", $2 * 1;}' < /proc/meminfo)k --vm-keep -m 10`
+- `stress-ng --matrix 0`
+- `sudo apt-get -y install fio`
+- `fio --name=test --rw=write --bs=1M --iodepth=32 --filename=/tmp/test --size=20G`
+
 ## Configure Prometheus and Grafana
 
 - `wget -qO- https://raw.githubusercontent.com/kolosovpetro/Prometheus/refs/heads/master/scripts/Install-Linux-Prometheus-Server.sh | sudo bash`

--- a/prometheus/cpu_rules.yml
+++ b/prometheus/cpu_rules.yml
@@ -1,8 +1,17 @@
 groups:
-  - name: cpu_alerts
+  - name: CpuRules
     rules:
-      - alert: HighCPUUsage
+      - alert: HighCPUUsageLinux
         expr: (100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High CPU usage detected on instance {{ $labels.instance }}"
+          description: "CPU usage is above 80% for more than 2 minutes on {{ $labels.instance }}."
+
+      - alert: HighCPUUsageWindows
+        expr: (100 - (avg by (instance) (rate(windows_cpu_time_total{mode="idle"}[5m])) * 100)) > 80
         for: 2m
         labels:
           severity: critical

--- a/prometheus/instance_shutdown_rules.yml
+++ b/prometheus/instance_shutdown_rules.yml
@@ -1,8 +1,14 @@
 groups:
-  - name: alert.rules
+  - name: ShutDownRules
     rules:
-      - alert: InstanceDown
+      - alert: InstanceDownLinux
         expr: up{instance="linux-target.razumovsky.me:9100"} == 0
+        for: 1m
+        labels:
+          severity: "critical"
+
+      - alert: InstanceDownWindows
+        expr: up{instance="windows-target.razumovsky.me:9182"} == 0
         for: 1m
         labels:
           severity: "critical"

--- a/prometheus/memory_rules.yml
+++ b/prometheus/memory_rules.yml
@@ -1,8 +1,17 @@
 groups:
   - name: MemoryThreshold
     rules:
-      - alert: HighRAMUsage
+      - alert: HighRAMUsageLinux
         expr: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 60
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High RAM usage on {{ $labels.instance }}"
+          description: "RAM usage on {{ $labels.instance }} is greater than 60%."
+
+      - alert: HighRAMUsageWindows
+        expr: 100 * (1 - (windows_memory_available_bytes / windows_memory_physical_total_bytes)) > 60
         for: 1m
         labels:
           severity: critical

--- a/prometheus/storage_rules.yml
+++ b/prometheus/storage_rules.yml
@@ -1,8 +1,17 @@
 groups:
   - name: StorageThreshold
     rules:
-      - alert: HighStorageUsage
+      - alert: HighStorageUsageLinux
         expr: 100 * (1 - (node_filesystem_avail_bytes / node_filesystem_size_bytes{mountpoint="/"})) > 50
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High storage usage on {{ $labels.instance }}"
+          description: "Storage usage on {{ $labels.instance }} is greater than 50%."
+
+      - alert: HighStorageUsageWindows
+        expr: 100 * (1 - (sum(windows_logical_disk_free_bytes) / sum(windows_logical_disk_size_bytes))) > 50
         for: 1m
         labels:
           severity: critical


### PR DESCRIPTION
## v1.0.0 - In Progress

### Changed

- Provisioned 3 virtual machines using Terraform modules
- Windows `WinRM` configured using Azure custom script extensions and Terraform
- Linux target node is provisioned with NGINX using Terraform `file` and `remote-exec` provisioners
- Windows target node is configured with node exporter and IIS using Terraform `file` and `remote-exec` provisioners
- Cloudflare `DNS records` are updated automatically via `PowerShell` using the IP addresses from Terraform state
- Azure custom script extension module for Linux is available too, but not used for the moment
- Whole infrastructure provision is fully automated using `Terraform` and `Azure pipelines`
- SSH keys copied securely inside Azure pipelines
- Fixed file encodings `(BOM characters, EOL)` to make sure consistent provision in Azure pipelines agent and locally
- Setup `sudo add-apt-repository` in non-interactive mode
- Efficient automatic upgrade of Linux system packages using Terraform `remote-exec` provisioners and `Bash`
- Efficient automatic provision of `Prometheus server` using `Bash` and Terraform `remote-exec`
  provisioners
- Efficient automatic provision of Linux `node exporter` for Prometheus using `Bash` and Terraform `remote-exec`
  provisioners
- Added `PowerShell` scripts for quick start and stop of VMs using `Az PowerShell`
- Deploy grafana
- Update readme
- Allow grafana port in NSG
- Configure Alert Manager
- Configure rules: CPU, RAM, Disk, Shutdown
- Minor fixes in scripts
- Configure rules: CPU, RAM, Disk, Shutdown (Windows)